### PR TITLE
Fix documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ a mechanism for tightly integrating outside systems into the Gladly platform.
 
 Use the tool to develop, test and build Gladly App Platform applications.
 
-The documentation for the tool's commands can be found [here](docs/appcfg-docs.md).
+The documentation for the tool's commands can be found [here](docs/appcfg.md).
 
 Documentation for the Gladly App Platform can be found [here](https://connect.gladly.com/docs/developer-tutorials/article/app-platform-overview/).
 


### PR DESCRIPTION
**What**

Fixes a documentation link that was left behind after a document reorganization.